### PR TITLE
Added possibility to never shutdown due to excessive drifting

### DIFF
--- a/relayer.go
+++ b/relayer.go
@@ -261,6 +261,11 @@ func (r *Relayer) StartRelayingBlocks(startBlockReady chan uint64, blockStore ds
 }
 
 func (r *Relayer) monitorDrift(driftMonitorDelay time.Duration) {
+	if r.maxDriftTolerance == 0 {
+		zlog.Info("max drift tolerance is set to 0, so we never shutdown due to excessive drifting, not monitoring drift")
+		return
+	}
+
 	// prevent shutting down too soon if joining took too long, which happens depending on live headblock vs file boundaries
 	<-time.After(driftMonitorDelay)
 	zlog.Info("now monitoring drift", zap.Duration("max_drift", r.maxDriftTolerance))


### PR DESCRIPTION
In phase 2 of syncing, would like to have a working relayer so that everything can be kept "warm". However, the `mindreader` might be drifting a lot since it's syncing back to some past blocks.

As such, it would be good to be able to specify `relayer-max-drift: 0` so that the relayer does not die while `mindreader` is catching up in this phase.

Opened this to gather feedback about potential other approaches, open to all suggestions. 

Also another thing strange is that while the "drift" is probably a few hours back, relayer report a drift value exceeding `1589551929583168027` which seems "impossible". I looked the code quick and did not catch what could cause this to report a such high value.

I should probably open a separate issue for this case.